### PR TITLE
feat: ui test with using react testing library

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,8 @@
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
     "require-atomic-updates": "off",
-    "no-console": "off"
+    "no-console": "off",
+    "prettier/prettier": "warn"
   },
   "settings": {
     "react": {

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,7 @@
 {
   "singleQuote": true,
   "semi": false,
-  "printWidth": 120
+  "printWidth": 120,
+  "trailingComma": "none",
+  "arrowParens": "avoid"
 }

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -35,6 +35,7 @@
     "@storybook/addons": "5.3.18",
     "@storybook/preset-typescript": "3.0.0",
     "@storybook/react": "5.3.18",
+    "@testing-library/react": "^10.0.2",
     "@types/electron-load-devtool": "^1.0.0",
     "@types/history": "4.7.5",
     "@types/jest": "25.1.4",
@@ -65,8 +66,8 @@
     "webpack-merge": "4.2.2"
   },
   "dependencies": {
-    "@babel/preset-env": "^7.7.1",
     "@abyssparanoia/interface": "0.0.1",
+    "@babel/preset-env": "^7.7.1",
     "@material-ui/core": "^4.9.7",
     "babel-plugin-import": "^1.12.2",
     "connected-react-router": "^6.7.0",

--- a/packages/electron/src/renderer/components/atoms/TextForm/TextForm.spec.tsx
+++ b/packages/electron/src/renderer/components/atoms/TextForm/TextForm.spec.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { render, fireEvent, screen } from '@testing-library/react'
+import { TextForm } from './TextForm'
+
+describe(`${TextForm.name}`, () => {
+  test('Snapshot', () => {
+    const component = render(<TextForm value="value" />)
+    const tree = component.baseElement
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('The onChange fires when the Change Event fires.', () => {
+    const onChange = jest.fn()
+    const VALUE = 'value'
+    render(<TextForm value={VALUE} onChange={onChange} />)
+    fireEvent.change(screen.getByDisplayValue(VALUE), {
+      target: { value: 'chuck' }
+    })
+    expect(onChange).toHaveBeenCalled()
+  })
+
+  test('The placeholder is working properly.', () => {
+    const PLACEHOLDER = 'placeholder'
+    render(<TextForm value={PLACEHOLDER} />)
+    expect(screen.getByDisplayValue(PLACEHOLDER))
+  })
+})

--- a/packages/electron/src/renderer/components/atoms/TextForm/__snapshots__/TextForm.spec.tsx.snap
+++ b/packages/electron/src/renderer/components/atoms/TextForm/__snapshots__/TextForm.spec.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiFormControl-root MuiTextField-root"
+    >
+      <div
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+      >
+        <input
+          aria-invalid="false"
+          class="MuiInputBase-input MuiInput-input"
+          type="text"
+          value="value"
+        />
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4297,7 +4297,7 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react@10.0.2":
+"@testing-library/react@10.0.2", "@testing-library/react@^10.0.2":
   version "10.0.2"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.0.2.tgz#8eca7aa52d810cf7150048a2829fdc487162006d"
   integrity sha512-YT6Mw0oJz7R6vlEkmo1FlUD+K15FeXApOB5Ffm9zooFVnrwkt00w18dUJFMOh1yRp9wTdVRonbor7o4PIpFCmA==


### PR DESCRIPTION
## Proposed Changes

I introduced the React DOM test as a lightweight UI test.

## Implementation

- I installed [React Testing Library](https://github.com/testing-library/react-testing-library) as a test framework.
- Event handler testing was introduced.
- Snapshot testing has been introduced.

⚠️ The prettier setting has been slightly modified.